### PR TITLE
add github link

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -308,3 +308,18 @@ kbd {
         overflow-x: auto;
     }
 }
+
+.footer {
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    color: rgba(0, 0, 0, 0.5);
+    font-size: 0.9rem;
+}
+
+body.dark-mode .footer {
+    background-color: #2a2a2a !important;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .footer .text-muted {
+    color: rgba(255, 255, 255, 0.6) !important;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -71,5 +71,15 @@
     <script src="https://cdn.datatables.net/colreorder/1.6.1/js/dataTables.colReorder.min.js"></script>
     
     {% block extra_js %}{% endblock %}
+
+    <footer class="footer mt-5 py-3 bg-light">
+        <div class="container text-center">
+            <span class="text-muted">
+                <a href="https://github.com/cjobermaier/mls-fantasy-data" target="_blank" class="text-decoration-none">
+                    <i class="fab fa-github me-1"></i> View on GitHub
+                </a>
+            </span>
+        </div>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
This pull request includes changes to add a footer to the website and style it appropriately for both light and dark modes. The most important changes include adding the footer HTML to the base template and defining the footer styles in the CSS file.

Changes to add a footer:

* [`app/templates/base.html`](diffhunk://#diff-9ba5b84a377a6a734932f7f6a3003e6f8bae1b02c34cf4729cfc95a5fd6179c8R74-R83): Added a footer section with a link to the GitHub repository.

Styling the footer:

* [`app/static/css/main.css`](diffhunk://#diff-2bf0c225b34aff304161f98f66fd831d745fc5074ceba600c226533fd781dc3bR311-R325): Defined styles for the footer, including different styles for light and dark modes.